### PR TITLE
Persistent PeerId, Fixing bundle error in SvelteKit and improved doc for command line args for WebSockets port  

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,29 @@ voyager daemon -d /path/to/voyager
 VOYAGER_PATH=/path/to/voyager voyager daemon
 ```
 
+#### Command Line Options
+
+Voyager daemon supports several command line options:
+
+**Port Configuration**
+- `--port, -p`: The port to listen on for the libp2p TCP transport. Defaults to 0 (random available port).
+- `--wsport, -w`: The port to listen on for WebSockets. Defaults to 0 (random available port).
+
+**Logging**
+- `--verbose, -v`: Enable verbose logging. Use multiple times (e.g., `-vvv`) for increased verbosity.
+
+**Access Control**
+- `--allow, -a`: Allow anyone to add a database. The default is false (deny all except explicitly authorized users).
+
+**Storage Location**
+- `--directory, -d`: Specify a directory to store Voyager, IPFS, and OrbitDB data. You can also use the `VOYAGER_PATH` environment variable.
+
+**Example with multiple options:**
+```sh
+voyager daemon -p 9090 -w 9091 -v --allow
+```
+
+
 ### Docker
 
 You can run an Voyager storage service using a pre-configured Docker image.


### PR DESCRIPTION
1. PeerId now persistent and taken from KeyStore where also OrbitDBs Identity is derived from.
2. Load NodeJS modules only in Nodejs and not in web applications. ***Remark: It's questionable if the alternative browser implementation is really needed here. (I currently doubt that, but I am not deep enough yet inside the voyager sources yet)***
3. Improved doc, so it becomes clear how to configure websocket port via command line args

